### PR TITLE
Added xarray dependency (used in dist.py)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numba
 pandas
 bokeh
 colorcet
+xarray


### PR DESCRIPTION
Attempting to use bokeh-catplot in a clean environment gives a stacktrace like:
```
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-2-4f37540e12c5> in <module>

---> 11 import bokeh_catplot

~/.local/lib/python3.6/site-packages/bokeh_catplot/__init__.py in <module>
     12 
     13 from .cat import *
---> 14 from .dist import *
     15 
     16 

~/.local/lib/python3.6/site-packages/bokeh_catplot/dist.py in <module>
      6 import numpy as np
      7 import pandas as pd
----> 8 import xarray
      9 import numba
     10 

ModuleNotFoundError: No module named 'xarray'
```

because the dist.py file depends on `xarray`, which is not in requirements.txt