### PR TITLE
Update README to remove deprecated ECDF usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ An empirical cumulative distribution function, or ECDF, is a convenient way to v
 
 > ECDF(x) = fraction of data points in X that are ≤ x.
 
-By default, ECDFs are colored by category. We could wish to display formal ECDFs (staircases).
+By default, ECDFs are colored by category. We could wish to display formal ECDFs (staircases) by setting the `style` kwarg.
 
 
 ```python
@@ -371,7 +371,7 @@ p = bokeh_catplot.ecdf(
     data=df,
     cats='origin',
     val='mpg',
-    formal=True,
+    style='staircase',
 )
 
 bokeh.io.show(p)
@@ -427,7 +427,7 @@ p = bokeh_catplot.ecdf(
     data=df,
     cats='origin',
     val='mpg',
-    formal=True,
+    style='staircase',
     conf_int=True,
 )
 


### PR DESCRIPTION
Changed from the old deprecated `formal=True` method of displaying a formal ECDF to the
new `style='staircase'` method of displaying the ECDF.

If you add deprecation warnings in, might as well update the docs :)